### PR TITLE
fix graph generation

### DIFF
--- a/src/graph.py
+++ b/src/graph.py
@@ -22,15 +22,21 @@
 
 from enum import Enum, unique
 from typing import Any, Dict, Optional, Set, Tuple
-from .schema import AccessPathLabel, ConstraintSet, DerivedTypeVariable, LoadLabel, StoreLabel, \
-        Variance
+from .schema import (
+    AccessPathLabel,
+    ConstraintSet,
+    DerivedTypeVariable,
+    LoadLabel,
+    StoreLabel,
+    Variance,
+)
 import networkx
 import os
 
 
 class EdgeLabel:
-    '''A forget or recall label in the graph. Instances should never be mutated.
-    '''
+    """A forget or recall label in the graph. Instances should never be mutated."""
+
     @unique
     class Kind(Enum):
         FORGET = 1
@@ -40,16 +46,18 @@ class EdgeLabel:
         self.capability = capability
         self.kind = kind
         if self.kind == EdgeLabel.Kind.FORGET:
-            type_str = 'forget'
+            type_str = "forget"
         else:
-            type_str = 'recall'
-        self._str = f'{type_str} {self.capability}'
+            type_str = "recall"
+        self._str = f"{type_str} {self.capability}"
         self._hash = hash(self.capability) ^ hash(self.kind)
 
     def __eq__(self, other: Any) -> bool:
-        return (isinstance(other, EdgeLabel) and
-                self.capability == other.capability and
-                self.kind == other.kind)
+        return (
+            isinstance(other, EdgeLabel)
+            and self.capability == other.capability
+            and self.kind == other.kind
+        )
 
     def __hash__(self) -> int:
         return self._hash
@@ -62,58 +70,70 @@ class EdgeLabel:
 
 
 class Node:
-    '''A node in the graph of constraints. Node objects are immutable.
+    """A node in the graph of constraints. Node objects are immutable.
 
     Forgotten is a flag used to differentiate between two subgraphs later in the algorithm. See
     :py:method:`Solver._recall_forget_split` for details.
-    '''
+    """
 
     @unique
     class Forgotten(Enum):
         PRE_FORGET = 0
         POST_FORGET = 1
 
-    def __init__(self,
-                 base: DerivedTypeVariable,
-                 suffix_variance: Variance,
-                 forgotten: Forgotten = Forgotten.PRE_FORGET) -> None:
+    def __init__(
+        self,
+        base: DerivedTypeVariable,
+        suffix_variance: Variance,
+        forgotten: Forgotten = Forgotten.PRE_FORGET,
+    ) -> None:
         self.base = base
         self.suffix_variance = suffix_variance
         if suffix_variance == Variance.COVARIANT:
-            variance = '.⊕'
+            variance = ".⊕"
         else:
-            variance = '.⊖'
+            variance = ".⊖"
         self._forgotten = forgotten
         if forgotten == Node.Forgotten.POST_FORGET:
-            self._str = 'F:' + str(self.base) + variance
+            self._str = "F:" + str(self.base) + variance
         else:
             self._str = str(self.base) + variance
-        self._hash = hash( (self.base, self.suffix_variance, self._forgotten) )
+        self._hash = hash((self.base, self.suffix_variance, self._forgotten))
 
     def __eq__(self, other: Any) -> bool:
-        return (isinstance(other, Node) and
-                self.base == other.base and
-                self.suffix_variance == other.suffix_variance and
-                self._forgotten == other._forgotten)
+        return (
+            isinstance(other, Node)
+            and self.base == other.base
+            and self.suffix_variance == other.suffix_variance
+            and self._forgotten == other._forgotten
+        )
 
     def __hash__(self) -> int:
         return self._hash
 
-    def forget_once(self) -> Tuple[Optional[AccessPathLabel], Optional['Node']]:
-        '''"Forget" the last element in the access path, creating a new Node. The new Node has
+    def forget_once(
+        self,
+    ) -> Tuple[Optional[AccessPathLabel], Optional["Node"]]:
+        """ "Forget" the last element in the access path, creating a new Node. The new Node has
         variance that reflects this change.
-        '''
+        """
         if self.base.path:
             prefix_path = list(self.base.path)
             last = prefix_path.pop()
             prefix = DerivedTypeVariable(self.base.base, prefix_path)
-            return (last, Node(prefix, Variance.combine(last.variance(), self.suffix_variance)))
+            return (
+                last,
+                Node(
+                    prefix,
+                    Variance.combine(last.variance(), self.suffix_variance),
+                ),
+            )
         return (None, None)
 
-    def recall(self, label: AccessPathLabel) -> 'Node':
-        '''"Recall" label, creating a new Node. The new Node has variance that reflects this
+    def recall(self, label: AccessPathLabel) -> "Node":
+        """ "Recall" label, creating a new Node. The new Node has variance that reflects this
         change.
-        '''
+        """
         path = list(self.base.path)
         path.append(label)
         variance = Variance.combine(self.suffix_variance, label.variance())
@@ -122,73 +142,97 @@ class Node:
     def __str__(self) -> str:
         return self._str
 
-    def split_recall_forget(self) -> 'Node':
-        '''Get a duplicate of self for use in the post-recall subgraph.
-        '''
-        return Node(self.base, self.suffix_variance, Node.Forgotten.POST_FORGET)
+    def split_recall_forget(self) -> "Node":
+        """Get a duplicate of self for use in the post-recall subgraph."""
+        return Node(
+            self.base, self.suffix_variance, Node.Forgotten.POST_FORGET
+        )
 
-    def inverse(self) -> 'Node':
-        '''Get a Node identical to this one but with inverted variance.
-        '''
-        return Node(self.base, Variance.invert(self.suffix_variance), self._forgotten)
+    def inverse(self) -> "Node":
+        """Get a Node identical to this one but with inverted variance."""
+        return Node(
+            self.base, Variance.invert(self.suffix_variance), self._forgotten
+        )
 
 
 class ConstraintGraph:
-    '''Represents the constraint graph in the slides. Essentially the same as the transducer from
+    """Represents the constraint graph in the slides. Essentially the same as the transducer from
     Appendix D. Edge weights use the formulation from the paper.
-    '''
+    """
+
     def __init__(self, constraints: ConstraintSet) -> None:
         self.graph = networkx.DiGraph()
         for constraint in constraints.subtype:
             self.add_edges(constraint.left, constraint.right)
-        self.add_forget_recall()
         self.saturate()
         self._remove_self_loops()
 
     def add_edge(self, head: Node, tail: Node, **atts) -> bool:
-        '''Add an edge to the graph. The optional atts dict should include, if anything, a mapping
+        """Add an edge to the graph. The optional atts dict should include, if anything, a mapping
         from the string 'label' to an EdgeLabel object.
-        '''
+        """
         if head not in self.graph or tail not in self.graph[head]:
             self.graph.add_edge(head, tail, **atts)
             return True
         return False
 
-    def add_edges(self, sub: DerivedTypeVariable, sup: DerivedTypeVariable, **atts) -> bool:
-        '''Add an edge to the underlying graph. Also add its reverse with reversed variance.
-        '''
+    def add_edges(
+        self, sub: DerivedTypeVariable, sup: DerivedTypeVariable, **atts
+    ) -> bool:
+        """Add an edge to the underlying graph. Also add its reverse with reversed variance.
+        Each constraint, becomes two pushdown rules in the paper.
+        In each case, we add recall edges only to the left-hand term of the rule
+        and forget edges to the right-hand side.
+        """
         changed = False
         forward_from = Node(sub, Variance.COVARIANT)
         forward_to = Node(sup, Variance.COVARIANT)
         changed = self.add_edge(forward_from, forward_to, **atts) or changed
+        self.add_recalls(forward_from)
+        self.add_forgets(forward_to)
         backward_from = forward_to.inverse()
         backward_to = forward_from.inverse()
         changed = self.add_edge(backward_from, backward_to, **atts) or changed
+        self.add_recalls(backward_from)
+        self.add_forgets(backward_to)
         return changed
 
-    def add_forget_recall(self) -> None:
-        '''Add forget and recall nodes to the graph. Step 4 in the notes.
-        '''
-        existing_nodes = set(self.graph.nodes)
-        for node in existing_nodes:
+    def add_recalls(self, node: Node) -> None:
+        """
+        Recall edges are added for the left-hand side of constraints
+        """
+        (capability, prefix) = node.forget_once()
+        while prefix:
+            self.add_edge(
+                prefix,
+                node,
+                label=EdgeLabel(capability, EdgeLabel.Kind.RECALL),
+            )
+            node = prefix
             (capability, prefix) = node.forget_once()
-            while prefix:
-                self.graph.add_edge(node,
-                                    prefix,
-                                    label=EdgeLabel(capability, EdgeLabel.Kind.FORGET))
-                self.graph.add_edge(prefix,
-                                    node,
-                                    label=EdgeLabel(capability, EdgeLabel.Kind.RECALL))
-                node = prefix
-                (capability, prefix) = node.forget_once()
+
+    def add_forgets(self, node: Node) -> None:
+        """
+        Forget edges are added for the right-hand side of constraints
+        """
+        (capability, prefix) = node.forget_once()
+        while prefix:
+            self.add_edge(
+                node,
+                prefix,
+                label=EdgeLabel(capability, EdgeLabel.Kind.FORGET),
+            )
+            node = prefix
+            (capability, prefix) = node.forget_once()
 
     def saturate(self) -> None:
-        '''Add "shortcut" edges, per algorithm D.2 in the paper.
-        '''
+        """Add "shortcut" edges, per algorithm D.2 in the paper."""
         changed = False
         reaching_R: Dict[Node, Set[Tuple[AccessPathLabel, Node]]] = {}
 
-        def add_forgets(dest: Node, forgets: Set[Tuple[AccessPathLabel, Node]]):
+        def add_forgets(
+            dest: Node, forgets: Set[Tuple[AccessPathLabel, Node]]
+        ):
             nonlocal changed
             if dest not in reaching_R or not (forgets <= reaching_R[dest]):
                 changed = True
@@ -202,23 +246,25 @@ class ConstraintGraph:
             return node.suffix_variance == Variance.CONTRAVARIANT
 
         for head_x, tail_y in self.graph.edges:
-            label = self.graph[head_x][tail_y].get('label')
+            label = self.graph[head_x][tail_y].get("label")
             if label and label.kind == EdgeLabel.Kind.FORGET:
                 add_forgets(tail_y, {(label.capability, head_x)})
         while changed:
             changed = False
             for head_x, tail_y in self.graph.edges:
-                if not self.graph[head_x][tail_y].get('label'):
+                if not self.graph[head_x][tail_y].get("label"):
                     add_forgets(tail_y, reaching_R.get(head_x, set()))
             existing_edges = list(self.graph.edges)
             for head_x, tail_y in existing_edges:
-                label = self.graph[head_x][tail_y].get('label')
+                label = self.graph[head_x][tail_y].get("label")
                 if label and label.kind == EdgeLabel.Kind.RECALL:
                     capability_l = label.capability
                     for (label, origin_z) in reaching_R.get(head_x, set()):
                         if label == capability_l:
                             add_edge(origin_z, tail_y)
-            contravariant_vars = list(filter(is_contravariant, self.graph.nodes))
+            contravariant_vars = list(
+                filter(is_contravariant, self.graph.nodes)
+            )
             for x in contravariant_vars:
                 for (capability_l, origin_z) in reaching_R.get(x, set()):
                     label = None
@@ -230,49 +276,56 @@ class ConstraintGraph:
                         add_forgets(x.inverse(), {(label, origin_z)})
 
     def _remove_self_loops(self) -> None:
-        '''Loops from a node directly to itself are not useful, so it's useful to remove them.
-        '''
-        self.graph.remove_edges_from({(node, node) for node in self.graph.nodes})
+        """Loops from a node directly to itself are not useful, so it's useful to remove them."""
+        self.graph.remove_edges_from(
+            {(node, node) for node in self.graph.nodes}
+        )
 
     @staticmethod
     def edge_to_str(graph, edge: Tuple[Node, Node]) -> str:
-        '''A helper for __str__ that formats an edge
-        '''
+        """A helper for __str__ that formats an edge"""
         width = 2 + max(map(lambda v: len(str(v)), graph.nodes))
         (sub, sup) = edge
-        label = graph[sub][sup].get('label')
-        edge_str = f'{str(sub):<{width}}→  {str(sup):<{width}}'
+        label = graph[sub][sup].get("label")
+        edge_str = f"{str(sub):<{width}}→  {str(sup):<{width}}"
         if label:
-            return edge_str + f' ({label})'
+            return edge_str + f" ({label})"
         else:
             return edge_str
 
     @staticmethod
     def graph_to_dot(name: str, graph: networkx.DiGraph) -> str:
-        nt = os.linesep + '\t'
+        nt = os.linesep + "\t"
+
         def edge_to_str(edge: Tuple[Node, Node]) -> str:
             (sub, sup) = edge
-            label = graph[sub][sup].get('label')
-            label_str = ''
+            label = graph[sub][sup].get("label")
+            label_str = ""
             if label:
                 label_str = f' [label="{label}"]'
             return f'"{sub}" -> "{sup}"{label_str};'
+
         def node_to_str(node: Node) -> str:
             return f'"{node}";'
-        return (f'digraph {name} {{{nt}{nt.join(map(node_to_str, graph.nodes))}{nt}'
-                f'{nt.join(map(edge_to_str, graph.edges))}{os.linesep}}}')
+
+        return (
+            f"digraph {name} {{{nt}{nt.join(map(node_to_str, graph.nodes))}{nt}"
+            f"{nt.join(map(edge_to_str, graph.edges))}{os.linesep}}}"
+        )
 
     @staticmethod
     def write_to_dot(name: str, graph: networkx.DiGraph) -> None:
-        with open(f'{name}.dot', 'w') as dotfile:
+        with open(f"{name}.dot", "w") as dotfile:
             print(ConstraintGraph.graph_to_dot(name, graph), file=dotfile)
 
     @staticmethod
     def graph_to_str(graph: networkx.DiGraph) -> str:
-        nt = os.linesep + '\t'
+        nt = os.linesep + "\t"
         edge_to_str = lambda edge: ConstraintGraph.edge_to_str(graph, edge)
-        return f'{nt.join(map(edge_to_str, graph.edges))}'
+        return f"{nt.join(map(edge_to_str, graph.edges))}"
 
     def __str__(self) -> str:
-        nt = os.linesep + '\t'
-        return f'ConstraintGraph:{nt}{ConstraintGraph.graph_to_str(self.graph)}'
+        nt = os.linesep + "\t"
+        return (
+            f"ConstraintGraph:{nt}{ConstraintGraph.graph_to_str(self.graph)}"
+        )

--- a/test/test_endtoend.py
+++ b/test/test_endtoend.py
@@ -465,7 +465,6 @@ class RecursiveSchemaTest(unittest.TestCase):
             constraints,
             callgraph,
             lattice=lattice,
-            config=SolverConfig(max_paths_per_root=1000),
         )
 
         gen = CTypeGenerator(sketches, lattice, CLatticeCTypes(), 4, 4)

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,0 +1,116 @@
+"""Simple unit tests from the paper and slides that only look at the final result (sketches)
+"""
+
+import unittest
+
+from retypd import (
+    ConstraintSet,
+    SchemaParser,
+)
+
+from retypd.schema import Variance
+from retypd.graph import ConstraintGraph, Node
+
+VERBOSE_TESTS = False
+
+
+class ConstraintGraphTest(unittest.TestCase):
+    def test_simple(self):
+        """
+        Check that the constraint graph from one constraint has the expected elements.
+        A constraint graph from one constraint has two paths that allow us to reconstruct
+        the constraint, one in covariant version and one in contravariant.
+        """
+        cs = ConstraintSet(
+            [SchemaParser.parse_constraint("f.in_0 <= A.load.σ4@0")]
+        )
+        graph = ConstraintGraph(cs).graph
+        f_co = Node(SchemaParser.parse_variable("f"), Variance.COVARIANT)
+        fin0_co = Node(
+            SchemaParser.parse_variable("f.in_0"), Variance.COVARIANT
+        )
+
+        a_load_0_co = Node(
+            SchemaParser.parse_variable("A.load.σ4@0"), Variance.COVARIANT
+        )
+        a_load_co = Node(
+            SchemaParser.parse_variable("A.load"), Variance.COVARIANT
+        )
+        a_co = Node(SchemaParser.parse_variable("A"), Variance.COVARIANT)
+
+        f_cn = Node(SchemaParser.parse_variable("f"), Variance.CONTRAVARIANT)
+        fin0_cn = Node(
+            SchemaParser.parse_variable("f.in_0"), Variance.CONTRAVARIANT
+        )
+
+        a_load_0_cn = Node(
+            SchemaParser.parse_variable("A.load.σ4@0"), Variance.CONTRAVARIANT
+        )
+        a_load_cn = Node(
+            SchemaParser.parse_variable("A.load"), Variance.CONTRAVARIANT
+        )
+        a_cn = Node(SchemaParser.parse_variable("A"), Variance.CONTRAVARIANT)
+        self.assertEqual(
+            {
+                f_co,
+                fin0_co,
+                a_load_0_co,
+                a_load_co,
+                a_co,
+                f_cn,
+                fin0_cn,
+                a_load_0_cn,
+                a_load_cn,
+                a_cn,
+            },
+            set(graph.nodes),
+        )
+
+        edges = {
+            # one path from "f" to "A"
+            (f_cn, fin0_co),
+            (fin0_co, a_load_0_co),
+            (a_load_0_co, a_load_co),
+            (a_load_co, a_co),
+            # the second path from "A" to "f"
+            (a_cn, a_load_cn),
+            (a_load_cn, a_load_0_cn),
+            (a_load_0_cn, fin0_cn),
+            (fin0_cn, f_co),
+        }
+        self.assertEqual(edges, set(graph.edges()))
+
+    def test_two_constraints(self):
+        """
+        A constraint graph from two related constraints has two paths
+        (a covariant and contravariant version) that allow us to conclude
+        that A.out <= C.
+        """
+        constraints = ["A <= B", "B.out <= C"]
+        cs = ConstraintSet(map(SchemaParser.parse_constraint, constraints))
+        graph = ConstraintGraph(cs).graph
+        b_co = Node(SchemaParser.parse_variable("B"), Variance.COVARIANT)
+        b_out_co = Node(
+            SchemaParser.parse_variable("B.out"), Variance.COVARIANT
+        )
+        a_co = Node(SchemaParser.parse_variable("A"), Variance.COVARIANT)
+        c_co = Node(SchemaParser.parse_variable("C"), Variance.COVARIANT)
+
+        b_cn = Node(SchemaParser.parse_variable("B"), Variance.CONTRAVARIANT)
+        b_out_cn = Node(
+            SchemaParser.parse_variable("B.out"), Variance.CONTRAVARIANT
+        )
+        a_cn = Node(SchemaParser.parse_variable("A"), Variance.CONTRAVARIANT)
+        c_cn = Node(SchemaParser.parse_variable("C"), Variance.CONTRAVARIANT)
+
+        edges = {
+            # path from A to C
+            (a_co, b_co),
+            (b_co, b_out_co),
+            (b_out_co, c_co),
+            # path from C to A
+            (c_cn, b_out_cn),
+            (b_out_cn, b_cn),
+            (b_cn, a_cn),
+        }
+        self.assertEqual(edges, set(graph.edges()))


### PR DESCRIPTION
Recall edges are only added to the left-hand side of constraints
whereas, forget edges are only added to the right-hand side.
Before both edges were added to both sides resulting in unnecessary cycles
and a combinational explosion in the graph.

The only methods actually changed are `_add_edges`  and `add_recall_forget`. I have also added some tests.
The rest of the changes are due to automatic formatting.